### PR TITLE
increase django requirement to 1.11.19 for security reasons

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ cffi==1.11.5
 chardet==3.0.4
 conda==4.5.12
 cryptography==2.4.2
-Django==1.11.17
+Django==1.11.19
 django-cors-headers==2.4.0
 django-registration-redux==1.4
 idna==2.8


### PR DESCRIPTION
As described https://docs.djangoproject.com/en/2.1/releases/1.11.18/ and https://docs.djangoproject.com/en/2.1/releases/1.11.19/ , there's a security issue regarding 1.11.17, so I've increased the requirements accordingly. These releases only fixed this issue, so nothing else should change as a result.